### PR TITLE
feat: allow adding wildcard to domains + enrich error message

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,12 +46,23 @@ function checkAndBlockSite(details) {
       const blockedWebsites = result.blockedWebsites || [];
 
       for (const website of blockedWebsites) {
-        const pattern = new RegExp(`^(www\\.)?${website.replace(/\./g, "\\.")}$`);
-        if (pattern.test(hostname)) {
-          chrome.tabs.update(details.tabId, {
-            url: chrome.runtime.getURL("html/blocked.html"),
-          });
-          break;
+        if (website.startsWith('*.')) {
+          const domainSuffix = website.substring(2);
+          if (hostname === domainSuffix || hostname.endsWith('.' + domainSuffix)) {
+            chrome.tabs.update(details.tabId, {
+              url: chrome.runtime.getURL("html/blocked.html"),
+            });
+            break;
+          }
+        }
+        else {
+          const pattern = new RegExp(`^(www\\.)?${website.replace(/\./g, "\\.")}$`);
+          if (pattern.test(hostname)) {
+            chrome.tabs.update(details.tabId, {
+              url: chrome.runtime.getURL("html/blocked.html"),
+            });
+            break;
+          }
         }
       }
     });

--- a/js/settings.js
+++ b/js/settings.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const { validDomains, invalidEntries } = processEntries(rawEntries);
 
     if (invalidEntries.length) {
-      showFeedbackMessage('Some entries are invalid. Please check.', 'red');
+      showFeedbackMessage('Some entries are invalid. Please check: ' + invalidEntries.join(','), 'red');
       return;
     }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -48,6 +48,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function extractDomain(url) {
+    if (url.startsWith('*.')) {
+      const domain = url.substring(2);
+      if (/^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(domain)) {
+        return url;
+      }
+      return null;
+    }
+
     try {
       const formattedUrl = url.startsWith('http') ? url : 'http://' + url;
       const hostname = new URL(formattedUrl).hostname.replace(/^www\./, '');


### PR DESCRIPTION
This pull request includes changes to allow users to provide wildcards to domains like `*.github.com` which allows blocking all subdomains as this isn't the default behavior of the application.

Another change appends the erroneous config entries to the error message to make debugging easier.