### PR TITLE
chore: remove linux/mips, linux/mips64, linux/mipsle, and linux/mips64le from release build targets

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-04-08T08:47:18.958186815Z",
-  "version": "1.3.3",
+  "generated_at": "2026-05-29T13:51:36.805789129Z",
+  "version": "1.3.4",
   "files": [
     {
       "path": ".editorconfig"


### PR DESCRIPTION
Remove linux/mips, linux/mips64, linux/mipsle, and linux/mips64le from release build targets.